### PR TITLE
extend repo with an example of the issue

### DIFF
--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -4,7 +4,6 @@ import {
   ISbStoriesParams,
   StoryblokStory,
 } from '@storyblok/react/rsc';
-import Link from "next/link";
 
 export default async function Home() {
   const { data } = await fetchData();
@@ -13,8 +12,6 @@ export default async function Home() {
     <div>
       <h1>Story: {data.story.id}</h1>
       <StoryblokStory story={data.story} />
-      <Link href={'/test'}>Go to test (next link)</Link>
-      <a href={'/test'}>Go to test (standard a tag)</a>
     </div>
   );
 }


### PR DESCRIPTION
Hi!

I've duplicated the original `page.tsx` so that there's a version of it under `/test`, and added a link to `/test` in the original page.

When navigating through the `next/link` component, you'll receive the error (sometimes in the server console, sometimes it'll appear in the browser too. On the odd occasion I've had it not show up at all!)
When navigating through the standard `a` tag, there is no error.

I don't believe the `@storyblok/react` package is at fault here, seems like the issue lies with Next.js ([see my original comment](https://github.com/storyblok/storyblok-react/issues/952#issuecomment-1964134879)), though you may be able to mitigate the problem.